### PR TITLE
Added support for Windows & fixed paths.

### DIFF
--- a/open_folder_in_vscode/__init__.py
+++ b/open_folder_in_vscode/__init__.py
@@ -1,7 +1,22 @@
 from fman import DirectoryPaneCommand
+from fman.url import as_human_readable
 from subprocess import Popen
+import os.path
+
 
 class OpenFolderInVSCode(DirectoryPaneCommand):
+    default_exe_path = 'code'
+    unix_exe_path = '/usr/local/bin/code'
+
     def __call__(self):
         path = self.pane.get_path()
-        Popen('/usr/local/bin/code "%s"' % path, shell=True)
+        # Convert path to one that the OS should understand (stripping 'file://' prefix and normalizing the path separator).
+        path = as_human_readable(path)
+        exe_path = self.get_exe_path()
+        Popen('{} "{}"'.format(exe_path, path), shell=True)
+
+    def get_exe_path(self):
+        # Use (default?) unix path if it exists
+        if os.path.isfile(self.unix_exe_path):
+            return self.unix_exe_path
+        return self.default_exe_path


### PR DESCRIPTION
Was kind of disappointed to notice the plugin didn't work on Windows. Using "code" as executable instead of the full Unix path. This should work on all supported platforms except Mac (see documentation: [https://code.visualstudio.com/docs/editor/command-line]).

Second issue was that URIs from the API are now prefixed with "file://" so the paths are now normalized/humanized to the OS default.

Probably fixes #3 as well.